### PR TITLE
support MAIL command with a null

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -468,8 +468,8 @@ func (proto *Protocol) STARTTLS(args string) (reply *Reply) {
 	return ReplyReadyToStartTLS(callback)
 }
 
-var parseMailBrokenRegexp = regexp.MustCompile("(?i:From):\\s*<([^>]+)>")
-var parseMailRFCRegexp = regexp.MustCompile("(?i:From):<([^>]+)>")
+var parseMailBrokenRegexp = regexp.MustCompile("(?i:From):\\s*<([^>]*)>")
+var parseMailRFCRegexp = regexp.MustCompile("(?i:From):<([^>]*)>")
 
 // ParseMAIL returns the forward-path from a MAIL command argument
 func (proto *Protocol) ParseMAIL(mail string) (string, error) {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -533,6 +533,9 @@ func TestParseMAIL(t *testing.T) {
 		m, err = proto.ParseMAIL("FROM:<oink>")
 		So(err, ShouldBeNil)
 		So(m, ShouldEqual, "oink")
+		m, err = proto.ParseMAIL("FROM:<>")
+		So(err, ShouldBeNil)
+		So(m, ShouldEqual, "")
 	})
 	Convey("ParseMAIL should return an error for invalid syntax", t, func() {
 		m, err := proto.ParseMAIL("FROM:oink")
@@ -550,6 +553,9 @@ func TestParseMAIL(t *testing.T) {
 		m, err = proto.ParseMAIL("FrOm:<oink@oink.mailhog.example>")
 		So(err, ShouldBeNil)
 		So(m, ShouldEqual, "oink@oink.mailhog.example")
+		m, err = proto.ParseMAIL("FrOm:<>")
+		So(err, ShouldBeNil)
+		So(m, ShouldEqual, "")
 	})
 	Convey("ParseMAIL should support broken sender syntax", t, func() {
 		m, err := proto.ParseMAIL("FROM: <oink>")
@@ -561,6 +567,9 @@ func TestParseMAIL(t *testing.T) {
 		m, err = proto.ParseMAIL("FrOm: <oink@oink.mailhog.example>")
 		So(err, ShouldBeNil)
 		So(m, ShouldEqual, "oink@oink.mailhog.example")
+		m, err = proto.ParseMAIL("FROM: <>")
+		So(err, ShouldBeNil)
+		So(m, ShouldEqual, "")
 	})
 	Convey("Error should be returned via Command", t, func() {
 		proto := NewProtocol()


### PR DESCRIPTION
MAIL command with a null is required in rfc5321 as shown below.

https://tools.ietf.org/html/rfc5321#section-3.6.3
```
One way to prevent loops in error reporting is to specify a null reverse-path
in the MAIL command of a notification message.
When such a message is transmitted, the reverse-path MUST be set to null
(see   Section 4.5.5 for additional discussion).
A MAIL command with a null reverse-path appears as follows:

  MAIL FROM:<>
```

In fact, Postfix bounce emails have MAIL command set to "FROM:<>".
But, MailHog validation judges "FROM:<>" as an error.
Therefore, Postfix bounce email cannot be received by MailHog.

This Pull Request allows you to receive Postfix bounce email by support MAIL command with a null.